### PR TITLE
Add pkg-config to Ubuntu Installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This repository has the following dependencies, which come from `libsnark`:
 
 * On Ubuntu 16.04 LTS:
 
-        $ sudo apt-get install build-essential cmake git libgmp3-dev libprocps4-dev python-markdown libboost-all-dev libssl-dev
+        $ sudo apt-get install build-essential cmake git libgmp3-dev libprocps4-dev python-markdown libboost-all-dev libssl-dev pkg-config
 
 * On Ubuntu 14.04 LTS:
 


### PR DESCRIPTION
I followed the directions on the README and got the following error when running cmake:
```
-- Could NOT find PkgConfig (missing:  PKG_CONFIG_EXECUTABLE) 
CMake Error at /usr/share/cmake-3.5/Modules/FindPkgConfig.cmake:418 (message):
  pkg-config tool not found
Call Stack (most recent call first):
  /usr/share/cmake-3.5/Modules/FindPkgConfig.cmake:532 (_pkg_check_modules_internal)
  depends/libsnark/depends/libfqfft/CMakeLists.txt:92 (pkg_check_modules)
```
I installed pkg-config and was able to successfully run cmake.

This PR adds pkg-config to the list of packages that should be installed for Ubuntu 16.04 LTS, so others don't have to install pkg-config seperately. It might also make sense to include pkg-config for 14.04, as well.